### PR TITLE
Buildkit windows clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Run `script/server` script to serve the application.
 
 NB: If you get a problem about "subdir not supported" during execution of `script/server`, 
 set the buildkit feature to false in Docker. 
-On Windows, you can do this in Docker Desktop>Settings>Build engine.
+On Windows, you can do this in Docker Desktop>Settings>Build engine. In addition, make sure that "Use Docker Compose V2" in the General settings in Docker Desktop is not selected.
 On Mac, you can do this in Docker Desktop>Preferences>Docker Engine. Edit the displayed JSON so that `"buildkit": false`, then restart Docker Desktop.
 
 ### Configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   rasa_server:
     build:
-      context: https://github.com/PerfectFit-project/virtual-coach-rasa.git#main:Rasa_Bot
+      context: https://github.com/PerfectFit-project/virtual-coach-rasa.git#slim_rasa:Rasa_Bot
       dockerfile: Dockerfile.rasa_server
     ports:
       - 5005:5005
@@ -28,7 +28,7 @@ services:
 
   rasa_actions:
     build:
-      context: https://github.com/PerfectFit-project/virtual-coach-rasa.git#main:Rasa_Bot/actions
+      context: https://github.com/PerfectFit-project/virtual-coach-rasa.git#slim_rasa:Rasa_Bot/actions
       dockerfile: Dockerfile.rasa_actions
     expose: ["5055"]
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   rasa_server:
     build:
-      context: https://github.com/PerfectFit-project/virtual-coach-rasa.git#slim_rasa:Rasa_Bot
+      context: https://github.com/PerfectFit-project/virtual-coach-rasa.git#main:Rasa_Bot
       dockerfile: Dockerfile.rasa_server
     ports:
       - 5005:5005
@@ -28,7 +28,7 @@ services:
 
   rasa_actions:
     build:
-      context: https://github.com/PerfectFit-project/virtual-coach-rasa.git#slim_rasa:Rasa_Bot/actions
+      context: https://github.com/PerfectFit-project/virtual-coach-rasa.git#main:Rasa_Bot/actions
       dockerfile: Dockerfile.rasa_actions
     expose: ["5055"]
     env_file:


### PR DESCRIPTION
I learned when setting up my windows laptop from scratch that docker compose v2 always uses buildkit, which leads to the buildkit error when trying to run the full application, even when buildkit is disabled in the docker engine settings.