### PR TITLE
Add debug message to make clear which release tag has been selected.

### DIFF
--- a/ansible/playbooks/start-prod.yml
+++ b/ansible/playbooks/start-prod.yml
@@ -3,6 +3,9 @@
   hosts: prod
   user: root
   tasks:
+    - name: Print out release version user has chosen for production
+      debug:
+        msg: "Moving prod to version {{ RELEASETAG }}"
     - name: Copy .env for staging
       ansible.builtin.copy:
         src: ../.env.prod


### PR DESCRIPTION
Fixes https://github.com/PerfectFit-project/virtual-coach-issues/issues/279

A test release (v0.1.0) has been made for the virtual-coach-rasa and niceday_components repositories, triggering packges tagged with `:0.1.0` as can be seen [here](https://github.com/orgs/PerfectFit-project/packages?repo_name=niceday-components) and [here](https://github.com/orgs/PerfectFit-project/packages?repo_name=virtual-coach-rasa)

I tested the ansible playbook, `start-prod.yml`, running with the version number (note, no 'v' is given here):
```
ansible-playbook -i inventory playbooks/start-prod.yml -e RELEASETAG=0.1.0
```
This worked well with the droplet on DigitalOcean.

This PR just adds a simple debug message to that playbook, to complete the issue.