### PR TITLE
Remove docker port mapping for security

### DIFF
--- a/ansible/prod/docker-compose.prod.yml
+++ b/ansible/prod/docker-compose.prod.yml
@@ -7,8 +7,6 @@ services:
       POSTGRES_DB: perfectfit
       POSTGRES_USER: root
       POSTGRES_PASSWORD: root
-    ports:
-      - "5432:5432"
 
   manage_db:
     build: https://github.com/PerfectFit-project/virtual-coach-db.git#main
@@ -20,20 +18,14 @@ services:
 
   rasa_server:
     image: ghcr.io/perfectfit-project/rasa_server:$RELEASETAG
-    ports:
-      - 5005:5005
-    expose: ["5005"]
 
   rasa_actions:
     image: ghcr.io/perfectfit-project/rasa_actions:$RELEASETAG
-    expose: ["5055"]
     env_file:
       - .env.prod
 
   redis:
     image: "redis:alpine"
-    ports:
-      - 6379:6379
 
   scheduler:
     image: ghcr.io/perfectfit-project/scheduler:$RELEASETAG
@@ -52,6 +44,3 @@ services:
     image: ghcr.io/perfectfit-project/niceday_api:$RELEASETAG
     env_file:
       - .env.prod
-    ports:
-      - 8080:8080
-    expose: ["8080"]

--- a/ansible/prod/docker-compose.prod.yml
+++ b/ansible/prod/docker-compose.prod.yml
@@ -2,6 +2,7 @@ version: "3.0"  # orig 3.0
 services:
   db:
     image: postgres
+    expose: ["5432"]
     restart: always
     environment:
       POSTGRES_DB: perfectfit
@@ -17,18 +18,22 @@ services:
       - .env.prod
 
   rasa_server:
+    expose: ["5005"]
     image: ghcr.io/perfectfit-project/rasa_server:$RELEASETAG
 
   rasa_actions:
     image: ghcr.io/perfectfit-project/rasa_actions:$RELEASETAG
+    expose: ["5055"]
     env_file:
       - .env.prod
 
   redis:
     image: "redis:alpine"
+    expose: ["6379"]
 
   scheduler:
     image: ghcr.io/perfectfit-project/scheduler:$RELEASETAG
+    expose: ["8080"]
     depends_on:
      - redis
      - rasa_server

--- a/ansible/stage/docker-compose.stage.yml
+++ b/ansible/stage/docker-compose.stage.yml
@@ -2,6 +2,7 @@ version: "3.0"  # orig 3.0
 services:
   db:
     image: postgres
+    expose: ["5432"]
     restart: always
     environment:
       POSTGRES_DB: perfectfit
@@ -18,17 +19,21 @@ services:
 
   rasa_server:
     image: ghcr.io/perfectfit-project/rasa_server:latest
+    expose: ["5005"]
 
   rasa_actions:
     image: ghcr.io/perfectfit-project/rasa_actions:latest
+    expose: ["5055"]
     env_file:
       - .env.stage
 
   redis:
     image: "redis:alpine"
+    expose: ["6379"]
 
   scheduler:
     image: ghcr.io/perfectfit-project/scheduler:latest
+    expose: ["8080"]
     depends_on:
      - redis
      - rasa_server

--- a/ansible/stage/docker-compose.stage.yml
+++ b/ansible/stage/docker-compose.stage.yml
@@ -7,8 +7,6 @@ services:
       POSTGRES_DB: perfectfit
       POSTGRES_USER: root
       POSTGRES_PASSWORD: root
-    ports:
-      - "5432:5432"
 
   manage_db:
     build: https://github.com/PerfectFit-project/virtual-coach-db.git#main
@@ -20,20 +18,14 @@ services:
 
   rasa_server:
     image: ghcr.io/perfectfit-project/rasa_server:latest
-    ports:
-      - 5005:5005
-    expose: ["5005"]
 
   rasa_actions:
     image: ghcr.io/perfectfit-project/rasa_actions:latest
-    expose: ["5055"]
     env_file:
       - .env.stage
 
   redis:
     image: "redis:alpine"
-    ports:
-      - 6379:6379
 
   scheduler:
     image: ghcr.io/perfectfit-project/scheduler:latest
@@ -52,6 +44,3 @@ services:
     image: ghcr.io/perfectfit-project/niceday_api:latest
     env_file:
       - .env.stage
-    ports:
-      - 8080:8080
-    expose: ["8080"]


### PR DESCRIPTION
Port mapping in the docker compose file exposes ports externally to the host. If the server does not have a properly set firewall then this means, for example, that an external attacker can see and connect to these open ports.

I have set up a firewall around our droplets, but I am still removing these port mappings from the prod and staging compose files. This could also be an issue if someone ever recreates a droplet without adding it to the firewall group.