### PR TITLE
Make cleaner ansible stage and prod upgrade

### DIFF
--- a/ansible/playbooks/start-prod.yml
+++ b/ansible/playbooks/start-prod.yml
@@ -23,5 +23,9 @@
         mode: '0644'
     - name: Log into docker ghcr
       shell: cat SECRET_read_private_packages_token | docker login ghcr.io -u USERNAME --password-stdin
+    - name: Stop docker compose (if up)
+      shell: 'RELEASETAG={{ RELEASETAG }} docker compose -f docker-compose.prod.yml down --remove-orphans --rmi all -v'
+    - name: Prune containers and networks
+      shell: 'docker system prune -a -f'
     - name: Start docker compose
       shell: "RELEASETAG={{ RELEASETAG }} docker compose -f docker-compose.prod.yml up -d"

--- a/ansible/playbooks/start-stage.yml
+++ b/ansible/playbooks/start-stage.yml
@@ -20,5 +20,9 @@
         mode: '0644'
     - name: Log into docker ghcr
       shell: cat SECRET_read_private_packages_token | docker login ghcr.io -u USERNAME --password-stdin
+    - name: Stop docker compose (if up)
+      shell: 'docker compose -f docker-compose.stage.yml down --remove-orphans --rmi all -v'
+    - name: Prune containers and networks
+      shell: 'docker system prune -a --volumes -f'
     - name: Start docker compose
       shell: 'docker compose -f docker-compose.stage.yml up -d'


### PR DESCRIPTION
Makes changes to the start-stage and start-prod ansible playbooks so that they ensure the virtual coach has been stopped, and all images/networks pruned, before trying to bring up the new version/release.