### PR TITLE
Update deployment readme and text

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -31,6 +31,12 @@ ansible stage -i inventory -m ping -u root
 
 If this is successful, then your inventory file is correctly set up.
 
+## Getting a token for reading private packages from the gchr
+The niceday-broker and niceday-client packages (built from the [niceday components](https://github.com/PerfectFit-project/niceday-components) repository) are private. This is because they use the `goaliejs` library (closed source). In order for the prod and stage servers to be able to pull these private packages, a token is needed that has permissions to read that repository. The current method is to use a 'machine user' (a github account only used for the purposes of automation). The machine user we are using is called [perfectfit-machineuser](https://github.com/perfectfit-machineuser) and is added as an outside collaborator with read-only access to the niceday-components repo. We then use the Personal Access Token of this machine-user to grant access to the private packages.
+
+Put the machine-user's Personal Access Token into a file called `SECRET_read_private_packages_token` in the same directory as the `inventory` file.
+ 
+
 ## Setting up the staging and production servers
 Now you can run the `initial-setup.yml` playbook, which installs docker, docker-compose and the general config environment on both the prod and stage servers defined in your `inventory` file. Run the notebook as follows:
 

--- a/ansible/playbooks/start-prod.yml
+++ b/ansible/playbooks/start-prod.yml
@@ -23,8 +23,10 @@
         mode: '0644'
     - name: Log into docker ghcr
       shell: cat SECRET_read_private_packages_token | docker login ghcr.io -u USERNAME --password-stdin
-    - name: Stop docker compose (if up)
+    - name: docker compose down the previous app (if up)
       shell: 'RELEASETAG={{ RELEASETAG }} docker compose -f docker-compose.prod.yml down --remove-orphans --rmi all -v'
+    - name: Stop any containers that may have been missed by the "docker compose down"
+      shell: 'docker stop $(docker container ls -q)'
     - name: Prune containers and networks
       shell: 'docker system prune -a -f'
     - name: Start docker compose

--- a/ansible/playbooks/start-prod.yml
+++ b/ansible/playbooks/start-prod.yml
@@ -1,12 +1,12 @@
 ---
-- name: Install docker
+- name: Updating production server
   hosts: prod
   user: root
   tasks:
     - name: Print out release version user has chosen for production
       debug:
         msg: "Moving prod to version {{ RELEASETAG }}"
-    - name: Copy .env for staging
+    - name: Copy .env for prod
       ansible.builtin.copy:
         src: ../.env.prod
         dest: ~/.env.prod

--- a/ansible/playbooks/start-stage.yml
+++ b/ansible/playbooks/start-stage.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install docker
+- name: Update staging server
   hosts: stage
   user: root
   tasks:

--- a/ansible/playbooks/start-stage.yml
+++ b/ansible/playbooks/start-stage.yml
@@ -22,6 +22,8 @@
       shell: cat SECRET_read_private_packages_token | docker login ghcr.io -u USERNAME --password-stdin
     - name: Stop docker compose (if up)
       shell: 'docker compose -f docker-compose.stage.yml down --remove-orphans --rmi all -v'
+    - name: Stop any containers that may have been missed by the "docker compose down"
+      shell: 'docker stop $(docker container ls -q)'
     - name: Prune containers and networks
       shell: 'docker system prune -a --volumes -f'
     - name: Start docker compose


### PR DESCRIPTION
This fixes some wrong names for ansible tasks and adds a section to the README explaining that the machine-user PAT is needed to read packages built with the private goaliejs lib.