### PR TITLE
Use new initdb naming

### DIFF
--- a/ansible/playbooks/start-prod.yml
+++ b/ansible/playbooks/start-prod.yml
@@ -27,6 +27,7 @@
       shell: 'RELEASETAG={{ RELEASETAG }} docker compose -f docker-compose.prod.yml down --remove-orphans --rmi all -v'
     - name: Stop any containers that may have been missed by the "docker compose down"
       shell: 'docker stop $(docker container ls -q)'
+      ignore_errors: true
     - name: Prune containers and networks
       shell: 'docker system prune -a -f'
     - name: Start docker compose

--- a/ansible/prod/docker-compose.prod.yml
+++ b/ansible/prod/docker-compose.prod.yml
@@ -1,19 +1,11 @@
 version: "3.0"  # orig 3.0
 services:
-  db:
-    image: postgres
-    expose: ["5432"]
-    restart: always
-    environment:
-      POSTGRES_DB: perfectfit
-      POSTGRES_USER: root
-      POSTGRES_PASSWORD: root
 
   manage_db:
     build: https://github.com/PerfectFit-project/virtual-coach-db.git#main
     tty: true
     restart: on-failure
-    command: ["/app/utils/init-db.sh"]
+    command: ["/app/utils/init-db-prod.sh"]
     env_file:
       - .env.prod
 

--- a/ansible/stage/docker-compose.stage.yml
+++ b/ansible/stage/docker-compose.stage.yml
@@ -13,7 +13,7 @@ services:
     build: https://github.com/PerfectFit-project/virtual-coach-db.git#main
     tty: true
     restart: on-failure
-    command: ["/app/utils/init-db.sh"]
+    command: ["/app/utils/init-db-tests.sh"]
     env_file:
       - .env.stage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     build: https://github.com/PerfectFit-project/virtual-coach-db.git#main
     tty: true
     restart: on-failure
-    command: ["/app/utils/init-db.sh"]
+    command: ["/app/utils/init-db-tests.sh"]
     env_file:
       - .env
 


### PR DESCRIPTION
Update the various docker compose files to handle the change in init scripts from PR https://github.com/PerfectFit-project/virtual-coach-db/pull/46

Also fixes a situation in which production playbook fails if docker has no containers to stop.